### PR TITLE
Init fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ addons:
       - libdw-dev
 
 rust:
-  - nightly
   - beta
   - stable
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: rust
+
+addons:
+  apt:
+    packages:
+      - libcurl4-openssl-dev
+      - libelf-dev
+      - libdw-dev
+
+rust:
+  - nightly
+  - beta
+  - stable
+
+# load travis-cargo
+before_script:
+  - |
+      pip install 'travis-cargo<0.2' --user &&
+      export PATH=$HOME/.local/bin:$PATH
+
+script:
+  - |
+      travis-cargo check
+
+env:
+  global:
+    # override the default `--features unstable` used for the nightly branch (optional)
+    - TRAVIS_CARGO_NIGHTLY_FEATURE=nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
 
 script:
   - |
-      travis-cargo check
+      travis-cargo build
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,3 @@ before_script:
 script:
   - |
       travis-cargo build
-
-env:
-  global:
-    # override the default `--features unstable` used for the nightly branch (optional)
-    - TRAVIS_CARGO_NIGHTLY_FEATURE=nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix build for non-Windows platforms
 
 ## [v0.2.0] - 2018-06-05
 Removed `init()`. Instead, ANSI is automatically enabled the first time an ANSI string is crated.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ extern crate itertools;
 use ansi_term::{ANSIGenericString, Colour};
 use difference::{Changeset, Difference};
 use itertools::Itertools;
-use std::{fmt, sync::Once};
+use std::fmt;
 
 fn red(s: &str) -> ANSIGenericString<str> {
     Colour::Red.paint(s)
@@ -25,12 +25,18 @@ static NL_LEFT: &str = "\n<";
 static RIGHT: &str = ">";
 static NL_RIGHT: &str = "\n>";
 
+#[cfg(windows)]
 #[inline(always)]
 fn enable_ansi() {
-    if cfg!(windows) {
-        static ONCE: Once = Once::new();
-        ONCE.call_once(|| {ansi_term::enable_ansi_support().ok();});
-    }
+    use std::sync::Once;
+
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {ansi_term::enable_ansi_support().ok();});
+}
+
+#[cfg(not(windows))]
+#[inline(always)]
+fn enable_ansi() {
 }
 
 #[derive(Copy, Clone, Debug)]


### PR DESCRIPTION
Non-Windows platforms would fail to compile with ansi_term v0.11.0 since `ansi_term::enable_ansi_support()` is under a `#[cfg(windows)]` attribute, and the `if cfg!(windows)` check only applies at runtime thus the code inside the if is still compiled.