### PR TITLE
Use wrapping sub to prevent underflow

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ fn fmt_changeset(f: &mut fmt::Formatter, changeset: &Changeset) -> fmt::Result {
                 format_same(f, text)?;
             }
             Difference::Add(added) => {
-                if let Some(Difference::Rem(removed)) = diffs.get(i.wrapping_sub(1)) {
+                if let Some(Difference::Rem(removed)) = i.checked_sub(1).map(|i| &diffs[i]) {
                     format_add_rem(f, added, removed)?;
                 } else {
                     format_add(f, added)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ fn fmt_changeset(f: &mut fmt::Formatter, changeset: &Changeset) -> fmt::Result {
                 format_same(f, text)?;
             }
             Difference::Add(added) => {
-                if let Some(Difference::Rem(removed)) = diffs.get(i - 1) {
+                if let Some(Difference::Rem(removed)) = diffs.get(i.wrapping_sub(1)) {
                     format_add_rem(f, added, removed)?;
                 } else {
                     format_add(f, added)?;
@@ -154,4 +154,18 @@ fn format_rem(f: &mut fmt::Formatter, text: &str) -> fmt::Result {
         writeln!(f, "{}{}", red(LEFT), red(line))?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_add() {
+        PrettyDifference {
+            expected: "",
+            actual: "foo",
+        }
+        .to_string();
+    }
 }


### PR DESCRIPTION
Fix possible underflow when first diff is an addition, see  #3.