### PR TITLE
fix: Switch from difference to dissimilar

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ is-it-maintained-open-issues = { repository = "https://github.com/CAD97/colored-
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
-difference = "2.0.0"
+dissimilar = "1.0"
 ansi_term = "0.11.0"
 itertools = { version = "0.7.8", default-features = false }
+[dev-dependencies]
+regex = "1.5.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
 extern crate ansi_term;
-extern crate difference;
+extern crate dissimilar;
 extern crate itertools;
+#[cfg(test)]
+extern crate regex;
 
 use ansi_term::{ANSIGenericString, Colour};
-use difference::{Changeset, Difference};
+use dissimilar::Chunk;
 use itertools::Itertools;
 use std::fmt;
 
@@ -53,11 +55,11 @@ impl<'a> fmt::Display for PrettyDifference<'a> {
 
 /// Format the difference between strings using GitHub-like formatting with ANSI coloring.
 pub fn diff(f: &mut fmt::Formatter, expected: &str, actual: &str) -> fmt::Result {
-    let changeset = Changeset::new(expected, actual, "\n");
+    let changeset = dissimilar::diff(expected, actual);
     fmt_changeset(f, &changeset)
 }
 
-fn fmt_changeset(f: &mut fmt::Formatter, changeset: &Changeset) -> fmt::Result {
+fn fmt_changeset(f: &mut fmt::Formatter, changeset: &Vec<Chunk>) -> fmt::Result {
     enable_ansi();
 
     writeln!(f, "{} {} / {} {}",
@@ -65,21 +67,20 @@ fn fmt_changeset(f: &mut fmt::Formatter, changeset: &Changeset) -> fmt::Result {
         green(RIGHT), green("right"),
     )?;
 
-    let diffs = &changeset.diffs;
-    for (i, diff) in diffs.iter().enumerate() {
+    for (i, diff) in changeset.iter().enumerate() {
         match diff {
-            Difference::Same(text) => {
+            Chunk::Equal(text) => {
                 format_same(f, text)?;
             }
-            Difference::Add(added) => {
-                if let Some(Difference::Rem(removed)) = i.checked_sub(1).map(|i| &diffs[i]) {
+            Chunk::Insert(added) => {
+                if let Some(Chunk::Delete(removed)) = i.checked_sub(1).map(|i| &changeset[i]) {
                     format_add_rem(f, added, removed)?;
                 } else {
                     format_add(f, added)?;
                 }
             }
-            Difference::Rem(removed) => {
-                if let Some(Difference::Add(_)) = diffs.get(i + 1) {
+            Chunk::Delete(removed) => {
+                if let Some(Chunk::Insert(_)) = changeset.get(i + 1) {
                     continue;
                 } else {
                     format_rem(f, removed)?;
@@ -92,23 +93,23 @@ fn fmt_changeset(f: &mut fmt::Formatter, changeset: &Changeset) -> fmt::Result {
 }
 
 fn format_add_rem(f: &mut fmt::Formatter, added: &str, removed: &str) -> fmt::Result {
-    let Changeset { diffs, .. } = Changeset::new(removed, added, "");
+    let diffs = dissimilar::diff(removed, added);
 
     // LEFT (removed)
     write!(f, "{}", red(LEFT))?;
     for diff in &diffs {
         match diff {
-            Difference::Same(text) => {
+            Chunk::Equal(text) => {
                 for blob in Itertools::intersperse(text.split('\n'), NL_LEFT) {
                     write!(f, "{}", red(blob))?;
                 }
             }
-            Difference::Rem(text) => {
-                for blob in Itertools::intersperse(text.split('\n'), NL_LEFT)  {
+            Chunk::Delete(text) => {
+                for blob in Itertools::intersperse(text.split('\n'), NL_LEFT) {
                     write!(f, "{}", on_red(blob))?;
                 }
             }
-            Difference::Add(_) => continue,
+            Chunk::Insert(_) => continue,
         }
     }
     writeln!(f)?;
@@ -117,17 +118,17 @@ fn format_add_rem(f: &mut fmt::Formatter, added: &str, removed: &str) -> fmt::Re
     write!(f, "{}", green(RIGHT))?;
     for diff in &diffs {
         match diff {
-            Difference::Same(text) => {
+            Chunk::Equal(text) => {
                 for blob in Itertools::intersperse(text.split('\n'), NL_RIGHT) {
                     write!(f, "{}", green(blob))?;
                 }
             }
-            Difference::Add(text) => {
-                for blob in Itertools::intersperse(text.split('\n'), NL_RIGHT)  {
+            Chunk::Insert(text) => {
+                for blob in Itertools::intersperse(text.split('\n'), NL_RIGHT) {
                     write!(f, "{}", on_green(blob))?;
                 }
             }
-            Difference::Rem(_) => continue,
+            Chunk::Delete(_) => continue,
         }
     }
     writeln!(f)?;
@@ -158,6 +159,8 @@ fn format_rem(f: &mut fmt::Formatter, text: &str) -> fmt::Result {
 
 #[cfg(test)]
 mod tests {
+    use regex::Regex;
+
     use super::*;
 
     #[test]
@@ -167,5 +170,31 @@ mod tests {
             actual: "foo",
         }
         .to_string();
+    }
+
+    #[test]
+    fn color_free_diff() {
+        let diff: String = PrettyDifference {
+            expected: "a\nb\nc",
+            actual: "\nb\ncc",
+        }
+        .to_string();
+
+        let re = Regex::new(r"\u{1b}\[[0-9;]*m").unwrap();
+        assert_eq!(
+            re.replace_all(&diff, ""),
+            "< left / > right\n<a\n \n b\n c\n>c\n"
+        );
+    }
+
+    #[test]
+    fn color_diff() {
+        let diff: String = PrettyDifference {
+            expected: "a\nb\nc",
+            actual: "\nb\ncc",
+        }
+        .to_string();
+
+        assert_eq!(diff, "\u{1b}[31m<\u{1b}[0m \u{1b}[31mleft\u{1b}[0m / \u{1b}[32m>\u{1b}[0m \u{1b}[32mright\u{1b}[0m\n\u{1b}[31m<\u{1b}[0m\u{1b}[31ma\u{1b}[0m\n \n b\n c\n\u{1b}[32m>\u{1b}[0m\u{1b}[32mc\u{1b}[0m\n");
     }
 }


### PR DESCRIPTION
cargo audit is warning when the difference is is used, it's no longer
maintained

https://rustsec.org/advisories/RUSTSEC-2020-0095
